### PR TITLE
Feature/prepare for exe

### DIFF
--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -14,7 +14,8 @@ jobs:
   build:
      strategy:
         matrix:
-          os: [macos-latest, ubuntu-latest, windows-latest]
+          # Linux builds are forwards but not backwards compatible
+          os: [macos-latest, ubuntu-20.04, windows-latest]
   
      runs-on: ${{ matrix.os }}
   

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -41,7 +41,7 @@ jobs:
              nuitka-version: main
              script-name: can_testbench.py
              # We want to configure options in the file but they set onefile default to true
-             # now we have to disable it here, sad
+             # now we have to disable it here
              onefile: false
              # many more Nuitka options available, see action doc, but it's best
              # to use nuitka-project: options in your code, so e.g. you can make

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -33,7 +33,7 @@ jobs:
     
         - name: Install your Dependencies
           run: |
-             pip install -r requirements.txt -r requirements-dev.txt
+             pip install -r requirements.txt
     
         - name: Build Executable with Nuitka
           uses: Nuitka/Nuitka-Action@main

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -52,4 +52,7 @@ jobs:
           with:
              name: ${{ runner.os }} Build
              path: | # Upload build folder
-                build/
+                build/can_testbench.dist/
+                build/*.exe
+                build/*.bin
+                build/*.app/**/*

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -14,8 +14,7 @@ jobs:
   build:
      strategy:
         matrix:
-          #os: [macos-latest, ubuntu-latest, windows-latest]
-          os: [ubuntu-latest, windows-latest]
+          os: [macos-latest, ubuntu-latest, windows-latest]
   
      runs-on: ${{ matrix.os }}
   

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -39,6 +39,9 @@ jobs:
           with:
              nuitka-version: main
              script-name: can_testbench.py
+             # We want to configure options in the file but they set onefile default to true
+             # now we have to disable it here, sad
+             onefile: false
              # many more Nuitka options available, see action doc, but it's best
              # to use nuitka-project: options in your code, so e.g. you can make
              # a difference for macOS and create an app bundle there.
@@ -47,5 +50,5 @@ jobs:
           uses: actions/upload-artifact@v3
           with:
              name: ${{ runner.os }} Build
-             path: | # Upload dist folder
-                dist/
+             path: | # Upload build folder
+                build/

--- a/can_send.py
+++ b/can_send.py
@@ -9,9 +9,10 @@ bus = None
 
 class msg_sender():
     
-    def __init__(self, msg: cantools.database.Message):
+    def __init__(self, msg: cantools.database.Message, bus: can.bus):
         super().__init__()
         self.msg = msg
+        self.bus = bus
         self.signal_values = {}
         self.signal_db = {}
         for signal in self.msg.signals:
@@ -28,7 +29,7 @@ class msg_sender():
     def send_message(self):
         data = self.msg.encode(self.signal_values)
         message = can.Message(arbitration_id=self.msg.frame_id, data=data, is_extended_id=True)
-        bus.send(message)
+        self.bus.send(message)
 
         for key in self.signal_values:
             if isinstance(self.signal_db[key], dict):
@@ -47,7 +48,7 @@ if __name__ == '__main__':
     msg_senders = set()
     for msg in db.messages:
         if 'VCU' not in msg.senders:
-            msg_senders.add(msg_sender(msg))
+            msg_senders.add(msg_sender(msg, bus))
         
     while True:
         for sender in msg_senders:

--- a/can_send.py
+++ b/can_send.py
@@ -6,32 +6,44 @@ from cantools.database.can.database import Database
 
 bus = None
 
-def send_message(msg):
-    signal_values = {}
-    signal_db = {}
-    for signal in msg.signals:
-        signal_values[signal.name] = signal.minimum
-        signal_db[signal.name] = {'minimum':signal.minimum, 'maximum':signal.maximum}
-
-    while True:
-        data = msg.encode(signal_values)
-        message = can.Message(arbitration_id=msg.frame_id, data=data, is_extended_id=True)
+class msg_sender():
+    
+    def __init__(self, msg: cantools.database.Message):
+        super().__init__()
+        self.msg = msg
+        self.signal_values = {}
+        self.signal_db = {}
+        for signal in self.msg.signals:
+            if signal.minimum is not None:
+                self.signal_values[signal.name] = signal.minimum
+                self.signal_db[signal.name] = {'minimum':signal.minimum, 'maximum':signal.maximum}
+            else:
+                self.signal_values[signal.name] = 0
+                self.signal_db[signal.name] = {'minimum':0, 'maximum':1}
+        
+    def send_message(self):
+        data = self.msg.encode(self.signal_values)
+        message = can.Message(arbitration_id=self.msg.frame_id, data=data, is_extended_id=True)
         bus.send(message)
 
-        for key in signal_values:
-            signal_values[key] += 1
-            if signal_values[key] > signal_db[key]['maximum']:
-                signal_values[key] = signal_db[key]['minimum']
-
-        time.sleep(1)  # Send a message every second
+        for key in self.signal_values:
+            self.signal_values[key] += 1
+            if self.signal_values[key] > self.signal_db[key]['maximum']:
+                self.signal_values[key] = self.signal_db[key]['minimum']
 
 if __name__ == '__main__':
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)
-    db = cantools.database.load_file('../envgo/dbc/xerotech_battery_j1939.dbc')
+    db = cantools.database.load_file('../envgo/dbc/nv1_syscan.dbc')
 
     assert(isinstance(db, Database))
-
+    
+    msg_senders = set()
     for msg in db.messages:
         if 'VCU' not in msg.senders:
-            send_message(msg)
-            break
+            msg_senders.add(msg_sender(msg))
+        
+    while True:
+        for sender in msg_senders:
+            sender.send_message()
+            
+        time.sleep(1)  # Send each message once a second

--- a/can_send.py
+++ b/can_send.py
@@ -41,7 +41,7 @@ class msg_sender():
 
 if __name__ == '__main__':
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)
-    db = cantools.database.load_file('../envgo/dbc/nv1_syscan.dbc')
+    db = cantools.database.load_file('../envgo/dbc/testbench.dbc')
 
     assert(isinstance(db, Database))
     

--- a/can_send.py
+++ b/can_send.py
@@ -3,6 +3,7 @@ import time
 import cantools
 import cantools.database
 from cantools.database.can.database import Database
+import random
 
 bus = None
 
@@ -17,6 +18,9 @@ class msg_sender():
             if signal.minimum is not None:
                 self.signal_values[signal.name] = signal.minimum
                 self.signal_db[signal.name] = {'minimum':signal.minimum, 'maximum':signal.maximum}
+            elif signal.choices is not None:
+                self.signal_db[signal.name] = list(signal.choices.keys())
+                self.signal_values[signal.name] = random.choice(self.signal_db[signal.name])
             else:
                 self.signal_values[signal.name] = 0
                 self.signal_db[signal.name] = {'minimum':0, 'maximum':1}
@@ -27,9 +31,12 @@ class msg_sender():
         bus.send(message)
 
         for key in self.signal_values:
-            self.signal_values[key] += 1
-            if self.signal_values[key] > self.signal_db[key]['maximum']:
-                self.signal_values[key] = self.signal_db[key]['minimum']
+            if isinstance(self.signal_db[key], dict):
+                self.signal_values[key] += 1
+                if self.signal_values[key] > self.signal_db[key]['maximum']:
+                    self.signal_values[key] = self.signal_db[key]['minimum']
+            else:
+                self.signal_values[key] = random.choice(self.signal_db[key])
 
 if __name__ == '__main__':
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -3,7 +3,6 @@
 # nuitka-project: --standalone
 # nuitka-project-if: {OS} == "Darwin":
 #    nuitka-project: --macos-create-app-bundle
-#    nuitka-project: --macos-app-icon=your-icon.png
 from __future__ import annotations
 import sys
 from os import path

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -534,12 +534,17 @@ class ConfigLayout(QWidget):
 
     def initBaseUI(self):
         screenSize = QApplication.primaryScreen().size()
+        self.mainLayout = QVBoxLayout()
+        self.horizontalLayout = QHBoxLayout()
+        self.mainLayout.addStretch(1)
+        self.mainLayout.addLayout(self.horizontalLayout, stretch = 0)
+        self.mainLayout.addStretch(5)
         
-        self.mainLayout = QHBoxLayout()
         self.configLayout = QGridLayout()
-        self.mainLayout.addSpacing(int(screenSize.width()*0.15))
-        self.mainLayout.addLayout(self.configLayout, stretch=0)
-        self.mainLayout.addSpacing(int(screenSize.width()*0.15))
+        self.configLayout.setVerticalSpacing(10)
+        self.horizontalLayout.addStretch(10)
+        self.horizontalLayout.addLayout(self.configLayout, stretch=50)
+        self.horizontalLayout.addStretch(10)
         
         infoLabel = QLabel()
         infoLabel.setText('DBC File:')

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -1,6 +1,8 @@
 # nuitka-project: --enable-plugin=pyside6
 # nuitka-project: --disable-console
 # nuitka-project: --standalone
+# nuitka-project-if: {OS} == "Darwin"
+#    nuitka-project: --macos-create-app-bundle
 from __future__ import annotations
 import sys
 from os import path

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -355,7 +355,7 @@ class MsgGraphWindow(QWidget):
 
     def updatePlot(self):
         # Find the length of the longest series
-        maxLength = max(len(signal.graphValues) for signal in self.msg.signals if signal.graphed)
+        maxLength = max((len(signal.graphValues) for signal in self.msg.signals if signal.graphed), default=0)
 
         for index, sig in enumerate(self.msg.signals):
             if sig.graphed:  # Only plot signals marked for graphing
@@ -494,7 +494,6 @@ class ConfigLayout(QWidget):
     
     def openDbc(self):
         file = QFileDialog.getOpenFileName(caption = "Open CAN Database file", dir = self.config.dbcFile, filter = "DBC file (*.dbc)")
-        print(file)
         if(file[1] != 'DBC file (*.dbc)'):
             return
         self.config.setDbc(file[0])
@@ -541,6 +540,7 @@ class ConfigLayout(QWidget):
             self.portBox.setText(port)
             self.portBox.setEnabled(True)
         else:
+            self.portBox.setText("")
             self.portBox.setEnabled(False)
 
     def initBaseUI(self):
@@ -802,7 +802,8 @@ class CanTabManager():
         counter = 1
         scriptDir = path.dirname(path.abspath(__file__))
         logDir = path.join(scriptDir, 'logs/')
-        logName = path.join(logDir, f"logfile_{datetime.datetime.now().date()}_{channel}")
+        channelName = sanitizeFileName(channel)
+        logName = path.join(logDir, f"logfile_{datetime.datetime.now().date()}_{channelName}")
         logType = "asc"
         while os.path.isfile(f"{logName}_{counter:02}.{logType}"):
             counter += 1
@@ -1048,6 +1049,10 @@ class MainApp(QMainWindow):
         # Call the superclass's closeEvent method to proceed with the closing
         super().closeEvent(event)
 
+def sanitizeFileName(name: str) -> str:
+    keepcharacters = (' ','.','_')
+    filename = "".join(c for c in name if c.isalnum() or c in keepcharacters).rstrip()
+    return filename
 
 if __name__ == '__main__':
     logger = logging.getLogger()

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -95,7 +95,7 @@ class CanListener(pycan.Listener):
         is received.  That is why it sends a signal.
 
         Parameters:
-        msg (can.Message): The message received.
+        msg (pycan.Message): The message received.
         """
         # Emit signal with the received CAN message and associated channel
         self.messageSignal.emit(msg, self.channel)
@@ -114,7 +114,7 @@ class CanBusHandler(QtCore.QObject):
     periodicMsg (dictionary): Keeps track of the data, and period of the message sent.
     Also the task sending the periodic message.
     listener (CanListener): The class that is listening for CAN messages
-    notifier (can.Notifier): The class that will notify on a message received from Python CAN.
+    notifier (pycan.Notifier): The class that will notify on a message received from Python CAN.
     """
     messageReceived = QtCore.Signal(pycan.Message, str)
 
@@ -126,8 +126,8 @@ class CanBusHandler(QtCore.QObject):
         self.listener = CanListener(self.messageReceived, channel)
         notifyList = [self.listener]
         if logFile != '':
-            #self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
-            self.logger = pycan.ASCWriter(logFile, channel)
+            self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
+            #self.logger = pycan.ASCWriter(logFile, channel)
             notifyList.append(self.logger)
         self.notifier = pycan.Notifier(self.bus, notifyList)
 
@@ -137,7 +137,7 @@ class CanBusHandler(QtCore.QObject):
         Or sets up a task to send periodic messages if frequency is not 0
 
         Parameters:
-        msg (can.Message): The message to be sent.
+        msg (pycan.Message): The message to be sent.
         frequency (int): The frequency of how often to send the message
         """
         if frequency == 0:
@@ -306,7 +306,7 @@ class MsgModel(QtCore.QAbstractTableModel):
     @property
     def msgData(self) -> bytes:
         """
-        Returns what the table represents as a can.Message
+        Returns what the table represents as a pycan.Message
 
         Parameters:
         None
@@ -804,7 +804,7 @@ class CanTabManager():
         logDir = path.join(scriptDir, 'logs/')
         channelName = sanitizeFileName(channel)
         logName = path.join(logDir, f"logfile_{datetime.datetime.now().date()}_{channelName}")
-        logType = "asc"
+        logType = "log"
         while os.path.isfile(f"{logName}_{counter:02}.{logType}"):
             counter += 1
         self.logFile = f"{logName}_{counter:02}.{logType}"

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -986,7 +986,7 @@ class MainApp(QMainWindow):
     def errorDialog(self, error):
         print(error)
         messageBox = QMessageBox()
-        messageBox.critical(self, "Error Opening File", repr(error))
+        messageBox.critical(self, "Error:", repr(error))
         messageBox.setFixedSize(500,200)
     
     @QtCore.Slot()

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -126,7 +126,8 @@ class CanBusHandler(QtCore.QObject):
         self.listener = CanListener(self.messageReceived, channel)
         notifyList = [self.listener]
         if logFile != '':
-            self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
+            #self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
+            self.logger = pycan.ASCWriter(logFile, channel)
             notifyList.append(self.logger)
         self.notifier = pycan.Notifier(self.bus, notifyList)
 
@@ -803,9 +804,10 @@ class CanTabManager():
         scriptDir = path.dirname(path.abspath(__file__))
         logDir = path.join(scriptDir, 'logs/')
         logName = path.join(logDir, f"logfile_{datetime.datetime.now().date()}_{channel}")
-        while os.path.isfile(f"{logName}_{counter:02}.log"):
+        logType = "asc"
+        while os.path.isfile(f"{logName}_{counter:02}.{logType}"):
             counter += 1
-        self.logFile = f"{logName}_{counter:02}.log"
+        self.logFile = f"{logName}_{counter:02}.{logType}"
         
         self.canBus = CanBusHandler(bus, self.channel, self.logFile)
         self.canBus.messageReceived.connect(self.handleRxCanMsg)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -3,6 +3,7 @@
 # nuitka-project: --standalone
 # nuitka-project-if: {OS} == "Darwin":
 #    nuitka-project: --macos-create-app-bundle
+#    nuitka-project: --macos-app-icon=your-icon.png
 from __future__ import annotations
 import sys
 from os import path

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -15,8 +15,8 @@ import dataclasses
 import collections
 import enum
 from cantools import database
+from cantools.database import namedsignalvalue
 from cantools.database.can import signal
-from cantools.database.namedsignalvalue import NamedSignalValue
 import can as pycan
 import logging
 import pyqtgraph as pg
@@ -247,7 +247,7 @@ class MsgModel(QtCore.QAbstractTableModel):
         if index.isValid() and index.column() == 5:
             if role == Qt.ItemDataRole.EditRole:
                 if self.rxTable:
-                    if isinstance(value, NamedSignalValue):
+                    if isinstance(value, namedsignalvalue.NamedSignalValue):
                         requestedValue = value.name
                         graphValue = value.value
                     else:
@@ -376,17 +376,10 @@ class MsgGraphWindow(QWidget):
                     del self.plotSeries[index]
 
     def closeEvent(self, event):
-        # Perform any cleanup or save data here
-        permitClose = True
-        
-        if permitClose:
-            self.graphWindowClosed.emit()
-            logging.debug('Closing graph window')
-            # Call the superclass's closeEvent method to proceed with the closing
-            super().closeEvent(event)
-        else:
-            logging.debug('Ignoring graph window close event')
-            event.ignore()
+        self.graphWindowClosed.emit()
+        logging.debug('Closing graph window')
+        # Call the superclass's closeEvent method to proceed with the closing
+        super().closeEvent(event)
 
 class Interface(enum.Enum):
     slcan = 0
@@ -855,7 +848,7 @@ class CanTabManager():
         for msg in dbcDb.messages:
             message = DbcMessage(message=msg, signals=[])
             for sig in msg.signals:
-                if isinstance(sig.initial, NamedSignalValue):
+                if isinstance(sig.initial, namedsignalvalue.NamedSignalValue):
                     value = sig.initial.name
                 elif(sig.is_float):
                     value = float(sig.initial) if sig.initial is not None else 0.0
@@ -973,7 +966,12 @@ class MainApp(QMainWindow):
 
         self.tabWidget.addTab(tab, 'CAN Config')
         tabBar = self.tabWidget.tabBar()
-        tabBar.tabButton(0, QTabBar.ButtonPosition.RightSide).resize(0, 0)
+        rightButton = tabBar.tabButton(0, QTabBar.ButtonPosition.RightSide)
+        leftButton = tabBar.tabButton(0, QTabBar.ButtonPosition.LeftSide)
+        if rightButton is not None:
+            rightButton.resize(0,0)
+        if leftButton is not None:
+            leftButton.resize(0, 0)
         
         if path.isfile(self.config.dbcFile):
             self.openDbc()

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -269,10 +269,15 @@ class MsgModel(QtCore.QAbstractTableModel):
                     else:
                         requestedValue = int(value)
 
-                    if ((self.msg.signals[index.row()].signal.minimum is None or
-                        requestedValue >= self.msg.signals[index.row()].signal.minimum) and
-                        (self.msg.signals[index.row()].signal.maximum is None or
-                        requestedValue <= self.msg.signals[index.row()].signal.maximum)):
+                    min = self.msg.signals[index.row()].signal.minimum
+                    max = self.msg.signals[index.row()].signal.maximum
+                    if min is None:
+                        min = -float('inf')
+                    if max is None:
+                        max = float('inf')
+
+                    if ((requestedValue >= min) and
+                        (requestedValue <=  max)):
                         self.msg.signals[index.row()].value = requestedValue
                         self.dataChanged.emit(index, index, [role])
                         return True

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -793,11 +793,15 @@ class CanTabManager():
     def __init__(self, config: CanConfig, channel: str, bus: pycan.bus):
         self.config = config
         self.channel = channel
-        counter = 0
-        self.logFile = f"./logs/logfile_{datetime.datetime.now().date()}_{channel}_{counter:02}.log"
-        while os.path.isfile(self.logFile):
+        
+        counter = 1
+        scriptDir = path.dirname(path.abspath(__file__))
+        logDir = path.join(scriptDir, 'logs/')
+        logName = path.join(logDir, f"logfile_{datetime.datetime.now().date()}_{channel}")
+        while os.path.isfile(f"{logName}_{counter:02}.log"):
             counter += 1
-            self.logFile = f"./logs/logfile_{datetime.datetime.now().date()}_{channel}_{counter:02}.log"
+        self.logFile = f"{logName}_{counter:02}.log"
+        
         self.canBus = CanBusHandler(bus, self.channel, self.logFile)
         self.canBus.messageReceived.connect(self.handleRxCanMsg)
         self.txMsgs = []
@@ -1038,7 +1042,9 @@ if __name__ == '__main__':
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     logging.info(sys.version)
-    os.makedirs("./logs", exist_ok=True)
+    scriptDir = path.dirname(path.abspath(__file__))
+    logDir = path.join(scriptDir, 'logs/')
+    os.makedirs(logDir, exist_ok=True)
     app = QApplication(sys.argv)
     mainApp = MainApp()
     mainApp.show()

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -671,6 +671,7 @@ class MessageLayout(QWidget):
         signalTableView.resizeRowsToContents()
         signalTableView.setAlternatingRowColors(True)
         self.resizeTableViewToContents(signalTableView)
+        signalTableView.horizontalHeader().setStretchLastSection(True)
         self.mainLayout.addWidget(signalTableView)
 
         self.setLayout(self.mainLayout)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -1,7 +1,7 @@
 # nuitka-project: --enable-plugin=pyside6
 # nuitka-project: --disable-console
 # nuitka-project: --standalone
-# nuitka-project-if: {OS} == "Darwin"
+# nuitka-project-if: {OS} == "Darwin":
 #    nuitka-project: --macos-create-app-bundle
 from __future__ import annotations
 import sys

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -1,6 +1,8 @@
 # nuitka-project: --enable-plugin=pyside6
 # nuitka-project: --disable-console
 # nuitka-project: --standalone
+# nuitka-project: --include-module=can.interfaces.slcan
+# nuitka-project: --include-module=can.interfaces.udp_multicast
 # nuitka-project-if: {OS} == "Darwin":
 #    nuitka-project: --macos-create-app-bundle
 from __future__ import annotations
@@ -501,6 +503,8 @@ class ConfigLayout(QWidget):
         self.dbcOpened.emit()
         
     def connectEnabled(self, bool):
+        style = "color: base" if bool else "color: red"
+        self.dbcBox.setStyleSheet(style)
         self.connectButton.setEnabled(bool)
     
     def changeInterface(self, index: int):
@@ -605,6 +609,7 @@ class ConfigLayout(QWidget):
         self.connectButton = QPushButton('Connect')
         self.connectButton.clicked.connect(self.connectPressed)
         self.connectButton.setEnabled(False)
+        self.dbcBox.setStyleSheet("color: red")
         self.configLayout.addWidget(self.connectButton, 6, 2)
         
         self.updateBoxes()


### PR DESCRIPTION
Allow for CAN to be configured from GUI without needing to modify code. Prepare for windows exe build. Almost all existing Pylance errors removed, no new pylance errors introduced. I also added logging. 

We've successfully launched the exe on a windows machine. Here are the builds: https://github.com/envgoinc/can_testbench/actions

### Changelog:

Connection settings
- UI for selecting bus type and connection options
- Options dynamically enabled/disabled based on selected bus type
- Options will be saved upon successful connection in config file, can simply hit connect button if desired config is unchanged from most recent use
- DBC files with initial values outside of the min max such as "Signal Not Available" no longer fail to open.
- Connect button disabled and red DBC path when no valid DBC is loaded.

Tab system
- More than one CAN connection can be opened at a time as long as the channel is unique
- If a channel is reopened, old tab and CAN connection will be closed
- Tabs can now be manually closed, will close the connection and both TX and RX tabs
- Graph window can now be manually closed and will correctly update the message table
- Fixed graph window remaining open when application or parent tab is closed
- Can connections shutdown properly when application or parent tab is closed

Miscellaneous
- Added logging system using the canutil *.log ASCII format.
- Named values will now have their names displayed in the table
- Pop up dialog for error messages with dynamic description
- Connection details at the top right on every tab so you don't mix them up
- Refactored code to improve maintainability
- Improved can_send.py script for more thorough testing.
- Fixed bug where once you stop sending a message, you can't send it again until you change frequency
- Github action to automate MacOS, Windows and Ubuntu builds
- A few other small bug fixes

Known issues
- If initial value is out of range such as "Signal Not Available", you cannot change back to it after switching off.