### PR TITLE
Feature/delaysendandsearch

### DIFF
--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -38,7 +38,8 @@ jobs:
         - name: Build Executable with Nuitka
           uses: Nuitka/Nuitka-Action@main
           with:
-             nuitka-version: main
+             # PySide6 dependencies aren't included properly for Ubuntu on recent versions
+             nuitka-version: 2.2.3
              script-name: can_testbench.py
              # We want to configure options in the file but they set onefile default to true
              onefile: false

--- a/.github/workflows/nuitka_build_exe.yml
+++ b/.github/workflows/nuitka_build_exe.yml
@@ -41,7 +41,6 @@ jobs:
              nuitka-version: main
              script-name: can_testbench.py
              # We want to configure options in the file but they set onefile default to true
-             # now we have to disable it here
              onefile: false
              # many more Nuitka options available, see action doc, but it's best
              # to use nuitka-project: options in your code, so e.g. you can make

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 *.asc
 
 *.ini
+
+.vscode/

--- a/can_send.py
+++ b/can_send.py
@@ -41,7 +41,7 @@ class msg_sender():
 
 if __name__ == '__main__':
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)
-    db = cantools.database.load_file('../envgo/dbc/testbench.dbc')
+    db = cantools.database.load_file('../envgo/dbc/testbench_motor.dbc')
 
     assert(isinstance(db, Database))
     

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -383,7 +383,7 @@ class TxMsgModel(MsgModel):
         return super().flags(index)
 
     def setData(self, index, value, role=Qt.ItemDataRole.EditRole):
-        if index.isValid() and index.column() == 5:
+        if index.isValid() and self.Columns[index.column()]['heading'] == 'Value':
             if role == Qt.ItemDataRole.EditRole:
                 # TX table
                 assert(isinstance(value, str))
@@ -817,8 +817,8 @@ class MessageLayout(QWidget):
         self.signalTableView.resizeRowsToContents()
         self.signalTableView.setAlternatingRowColors(True)
         self.resizeTableViewToContents(self.signalTableView)
-        self.signalTableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
-        self.signalTableView.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeMode.Stretch)
+        self.signalTableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
+        self.signalTableView.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
         self.mainLayout.addWidget(self.signalTableView)
 
         self.setLayout(self.mainLayout)
@@ -835,7 +835,7 @@ class TxMessageLayout(MessageLayout):
     discardPressed = QtCore.Signal()
     sendChanged = QtCore.Signal(bool)
     frequencyChanged = QtCore.Signal(int)
-    ColumnWidths = [300, 500, 50, 100, 100, 150, 100]
+    ColumnWidths = [300, 500, 50, 100, 100, 100, 50]
     
     def __init__(self, msgTable: TxMsgModel, msg: DbcMessage):
         super().__init__(msgTable, msg) # Initialize base UI components

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -665,7 +665,10 @@ class MessageLayout(QWidget):
         self.bottomHorizontal = QHBoxLayout()
         self.msgLabel = QLabel()
         self.msgLabel.setText(self.msgTableModel.msgLabel)
-        self.bottomHorizontal.addWidget(self.msgLabel)
+        msgSize = self.msgLabel.sizePolicy()
+        msgSize.setHorizontalPolicy(QSizePolicy.Policy.Ignored)
+        self.msgLabel.setSizePolicy(msgSize)
+        self.bottomHorizontal.addWidget(self.msgLabel, Qt.AlignmentFlag.AlignLeft)
         self.mainLayout.addLayout(self.bottomHorizontal)
 
 class TxMessageLayout(MessageLayout):
@@ -716,7 +719,7 @@ class TxMessageLayout(MessageLayout):
         logging.debug('tx initUI')
         freqComboLayout = QHBoxLayout()
         sendFrequencyLabel = QLabel('Select Send Frequency')
-        freqComboLayout.addStretch(2)
+        freqComboLayout.addStretch(1)
         freqComboLayout.addWidget(sendFrequencyLabel)
         self.sendFrequencyCombo = QComboBox()
         for value in self.FrequencyValues:
@@ -729,7 +732,7 @@ class TxMessageLayout(MessageLayout):
         self.frequencyChanged.connect(self.msgTableModel.frequencyChanged)
         freqComboLayout.addWidget(self.sendFrequencyCombo)
         freqComboLayout.setSpacing(0)
-        freqComboLayout.addStretch(1)
+        freqComboLayout.addSpacing(100)
         self.bottomHorizontal.addLayout(freqComboLayout)
         
         #self.discardButton = QPushButton('Discard')

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -809,10 +809,10 @@ class CanConfig():
         self.initConfig()
         
     def initConfig(self):
-        if not path.isfile(self.configFile):
-            self.writeConfig()
-        else:
+        try:
             self.readConfig()
+        except Exception as error:
+            self.writeConfig()
             
     def writeConfig(self):
         self.config['General'] = {

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -311,6 +311,7 @@ class RxMsgModel(MsgModel):
                     requestedValue = value
                     graphValue = value
                 self.msg.signals[index.row()].value = requestedValue
+                print("edited " + str(requestedValue))
                 self.dataChanged.emit(index, index, [role])
                 self.signalValueChanged.emit(self.msg,
                                                 index.row(),

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -16,6 +16,7 @@ import collections
 import enum
 from cantools import database
 from cantools.database import namedsignalvalue
+from cantools.database import Message
 from cantools.database.can import signal
 import can as pycan
 import logging
@@ -74,7 +75,7 @@ class DbcMessage:
     signals (list of DbcSignals): List of DbcSignals
     graphWindow (object): Represents the window that is showing the graph of signals
     """
-    message: pycan.Message
+    message: database.Message
     signals: list[DbcSignal]
     graphWindow: MsgGraphWindow | None = None
 
@@ -1333,7 +1334,6 @@ class CanTabManager():
                     value = int(sig.initial) if sig.initial is not None else 0
                 else:
                     value = float(sig.initial) if sig.initial is not None else 0.0
-
                 signal = DbcSignal(signal=sig, value=value)
                 message.signals.append(signal)
             if msg.senders is not None and 'VCU' in msg.senders:
@@ -1350,11 +1350,11 @@ class CanTabManager():
         tabWidget.setTabWhatsThis(tabWidget.count() - 1 ,self.channel)
         
     def shutdown(self):
-        self.canBus.shutdown()
         if self.txTab:
             self.txTab.deleteLater()
         if self.rxTab:
             self.rxTab.deleteLater()
+        self.canBus.shutdown()
         
 class MainApp(QMainWindow):
     """

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -275,7 +275,10 @@ class RxMsgModel(MsgModel):
         if role == Qt.ItemDataRole.DisplayRole:
             sig = self.msg.signals[index.row()]
             if self.Columns[index.column()]['editable']:
-                return str(self.msg.signals[index.row()].value)
+                if isinstance(self.msg.signals[index.row()].value, float):
+                    return str(round(self.msg.signals[index.row()].value, 2))
+                else:
+                    return str(self.msg.signals[index.row()].value)
             else:
                 return getattr(sig.signal, self.Columns[index.column()]['property'])
         elif role == Qt.ItemDataRole.CheckStateRole and index.column() == 5:
@@ -311,7 +314,6 @@ class RxMsgModel(MsgModel):
                     requestedValue = value
                     graphValue = value
                 self.msg.signals[index.row()].value = requestedValue
-                print("edited " + str(requestedValue))
                 self.dataChanged.emit(index, index, [role])
                 self.signalValueChanged.emit(self.msg,
                                                 index.row(),
@@ -346,7 +348,6 @@ class RxMsgModel(MsgModel):
         rxDataStr = ''.join(f'0x{byte:02x} ' for byte in rxData)[:-1]
         logging.debug(f'{rxDataStr=}')
         msgLabel = hex(self.msg.message.frame_id) + ': <' + rxDataStr + '>' + self.rxStatus
-        print(msgLabel)
         self.msgLabel = msgLabel
         self.setMsgLabel.emit(self.msgLabel)
         logging.debug(f'Data changed: {msgLabel}')
@@ -390,9 +391,15 @@ class TxMsgModel(MsgModel):
         if role == Qt.ItemDataRole.DisplayRole:
             sig = self.msg.signals[index.row()]
             if self.Columns[index.column()]['heading'] == 'Sent':
-                return str(self.msg.signals[index.row()].value)
+                if isinstance(self.msg.signals[index.row()].value, float):
+                    return str(round(self.msg.signals[index.row()].value, 2))
+                else:
+                    return str(self.msg.signals[index.row()].value)
             elif self.Columns[index.column()]['heading'] == 'Value':
-                return str(self.sigValues[index.row()])
+                if isinstance(self.sigValues[index.row()], float):
+                    return str(round(self.sigValues[index.row()], 2))
+                else:
+                    return str(self.sigValues[index.row()])
             else:
                 return getattr(sig.signal,self.Columns[index.column()]['property'])
         elif role == Qt.ItemDataRole.BackgroundRole:
@@ -636,8 +643,8 @@ class MessageLayout(QWidget):
         self.signalTableView.resizeRowsToContents()
         self.signalTableView.setAlternatingRowColors(True)
         self.resizeTableViewToContents(self.signalTableView)
-        self.signalTableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
-        self.signalTableView.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        self.signalTableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        self.signalTableView.horizontalHeader().setStretchLastSection(True)
         #self.signalTableView.setSelectionMode(QTableView.SelectionMode.ContiguousSelection)
         self.setFocusProxy(self.signalTableView)
         self.mainLayout.addWidget(self.signalTableView)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -352,7 +352,7 @@ class TxMsgModel(MsgModel):
         super().__init__(msg, parent)
         self.bus = bus
         self.sendMsg = False
-        self.changesQueued = False
+        self.isChangeQueued = False
         self.sigValues = {}
         self.sendLabel = ''
         for row in range(self.rowCount()):
@@ -405,8 +405,8 @@ class TxMsgModel(MsgModel):
                     self.sigValues[index.row()] = requestedValue
                     if self.sendMsg:
                         self.changeQueued.emit(True)
-                        self.changesQueued = True
-                    elif self.changesQueued == False:
+                        self.isChangeQueued = True
+                    elif self.isChangeQueued == False:
                         self.applyChange()
                     self.dataChanged.emit(index, index, [role])
                     return True
@@ -418,14 +418,14 @@ class TxMsgModel(MsgModel):
         self.updateSendString()
         self.dataChanged.emit(self.index(0, 5), self.index(self.rowCount()-1, 6), Qt.ItemDataRole.EditRole)
         self.changeQueued.emit(False)
-        self.changesQueued = False
+        self.isChangeQueued = False
         
     def discardChange(self):
         for row in range(self.rowCount()):
             self.sigValues[row] = self.msg.signals[row].value
         self.dataChanged.emit(self.index(0, 5), self.index(self.rowCount()-1, 6), Qt.ItemDataRole.EditRole)
         self.changeQueued.emit(False)
-        self.changesQueued = False
+        self.isChangeQueued = False
             
     def sendChanged(self, sendMsg):
         if sendMsg:
@@ -878,6 +878,7 @@ class TxMessageLayout(MessageLayout):
         index = self.sendFrequencyCombo.findData(self.msgTableModel.frequency)
         if index != -1:
             self.sendFrequencyCombo.setCurrentIndex(index)
+        self.sendFrequencyCombo.setFocusProxy(self.signalTableView)
         self.sendFrequencyCombo.currentIndexChanged.connect(self.emitFrequencyChanged)
         self.frequencyChanged.connect(self.msgTableModel.frequencyChanged)
         freqComboLayout.addWidget(self.sendFrequencyCombo)
@@ -887,12 +888,15 @@ class TxMessageLayout(MessageLayout):
         
         self.discardButton = QPushButton('Discard')
         self.discardButton.clicked.connect(self.discardPressed)
+        self.discardButton.setFocusProxy(self.signalTableView)
         canSendLayout.addWidget(self.discardButton)
         self.applyButton = QPushButton('Apply')
         self.applyButton.clicked.connect(self.applyPressed)
+        self.applyButton.setFocusProxy(self.signalTableView)
         canSendLayout.addWidget(self.applyButton)
         self.onChangeQueued(False)
         self.sendCheckBox = QCheckBox('Send')
+        self.sendCheckBox.setFocusProxy(self.signalTableView)
         self.sendCheckBox.stateChanged.connect(self.emitSendChanged)
         self.sendChanged.connect(self.msgTableModel.sendChanged)
         canSendLayout.addWidget(self.sendCheckBox)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -424,11 +424,8 @@ class TxMsgModel(MsgModel):
                 if value[:2] == '0x':
                     requestedValue = int(value, 16)
                 else:
-                    isFloat = self.msg.signals[index.row()].signal.is_float
-                    if isFloat:
-                        requestedValue = float(value)
-                    else:
-                        requestedValue = int(value)
+                    scale = self.msg.signals[index.row()].signal.scale
+                    requestedValue = round(float(value)/scale) * scale
 
                 min = self.msg.signals[index.row()].signal.minimum
                 max = self.msg.signals[index.row()].signal.maximum
@@ -1325,10 +1322,10 @@ class CanTabManager():
             for sig in msg.signals:
                 if isinstance(sig.initial, namedsignalvalue.NamedSignalValue):
                     value = sig.initial.name
-                elif(sig.is_float):
-                    value = float(sig.initial) if sig.initial is not None else 0.0
-                else:
+                elif(sig.scale == int(sig.scale)):
                     value = int(sig.initial) if sig.initial is not None else 0
+                else:
+                    value = float(sig.initial) if sig.initial is not None else 0.0
 
                 signal = DbcSignal(signal=sig, value=value)
                 message.signals.append(signal)

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -182,13 +182,8 @@ class MsgModel(QtCore.QAbstractTableModel):
     is transmitted from the app or received by the app.
 
     Attributes:
-    signalValueChanged (Qt.Signal): A class attribute that represents the signal
-    to be sent if the value of a can Signal in the table changes.
-    signalGraphedChanged (Qt.Signal): A signal to be sent if the graphed status
-    of a can Signal in the table changes.
     Columns (dict): A class attribute describing the columns in the table
     msg (DbcMessage): The message the table is displaying
-    rxTable (bool): True if this is a table that describes messages the app receives
     """
     setMsgLabel = QtCore.Signal(str)
     Columns = [
@@ -266,7 +261,6 @@ class RxMsgModel(MsgModel):
     of a can Signal in the table changes.
     Columns (dict): A class attribute describing the columns in the table
     msg (DbcMessage): The message the table is displaying
-    rxTable (bool): True if this is a table that describes messages the app receives
     """
     signalValueChanged = QtCore.Signal(DbcMessage, int, float)
     signalGraphedChanged = QtCore.Signal(DbcMessage, int, bool, object)
@@ -362,13 +356,8 @@ class TxMsgModel(MsgModel):
     is transmitted from the app or received by the app.
 
     Attributes:
-    signalValueChanged (Qt.Signal): A class attribute that represents the signal
-    to be sent if the value of a can Signal in the table changes.
-    signalGraphedChanged (Qt.Signal): A signal to be sent if the graphed status
-    of a can Signal in the table changes.
     Columns (dict): A class attribute describing the columns in the table
     msg (DbcMessage): The message the table is displaying
-    rxTable (bool): True if this is a table that describes messages the app receives
     """
     changeQueued = QtCore.Signal(bool)
     setSend = QtCore.Signal(bool)
@@ -585,10 +574,11 @@ class MsgGraphWindow(QWidget):
 
 class MessageLayout(QWidget):
     """
-    A class that represents the table that shows the Message
+    A class to manage the layout and view for a Message table
 
     Attributes:
-
+    msgTable (MsgModel): The table model holding our message data
+    msg (DbcMessage): The message associated with our table model
     """
     FrequencyValues = [0, 1, 5, 10, 20, 40, 50, 100]
     ColumnWidths = [300, 500, 50, 100, 100, 150]
@@ -667,11 +657,12 @@ class MessageLayout(QWidget):
 
 class TxMessageLayout(MessageLayout):
     """
-    A class that represents a table that shows a Message that can be transmitted
-    on the can bus
-
+    A class to manage the layout and view for a Message table that
+    can be transmitted
+    
     Attributes:
-
+    msgTable (MsgModel): The table model holding our message data
+    msg (DbcMessage): The message associated with our table model
     """
     applyPressed = QtCore.Signal()
     discardPressed = QtCore.Signal()
@@ -750,13 +741,12 @@ class TxMessageLayout(MessageLayout):
         self.bottomHorizontal.addWidget(self.sendCheckBox)
 
 class RxMessageLayout(MessageLayout):
-    
     """
-    A class that represents a table that shows a Message that can be received
-    on the can bus
-
+    A class to manage the layout and view for a Message table
+    that can be received
     Attributes:
-
+    msgTable (MsgModel): The table model holding our message data
+    msg (DbcMessage): The message associated with our table model
     """
     def __init__(self, msgTable: RxMsgModel, msg: DbcMessage):
         super().__init__(msgTable, msg)
@@ -1300,12 +1290,11 @@ class CanTabManager():
     Attributes:
     config (CanConfig): Source of truth for current config
     channel (str): Channel that the associated bus is connected to
-    canBus (CanBushandler): Associated bus
-    txMsgs (list): DbcMessages for our Tx tab
-    rxMsgs (list): Dbcmessages for our Rx tab
-    RxMsgTables (dict[RxMsgTable]): All the tables of message signals and their associated message id
+    bus (pycan.bus): Associated bus
+    dbcDb (Database): Dbc data containing messages we will use
+    tabWidget (QTabWidget): The tab widget to add tabs to
     """
-    def __init__(self, config: CanConfig, channel: str, bus: pycan.bus, dbcDb, tabWidget):
+    def __init__(self, config: CanConfig, channel: str, bus: pycan.bus, dbcDb, tabWidget: QTabWidget):
         self.config = config
         self.channel = channel
         


### PR DESCRIPTION
Adding some new features. Moved logic from derived MsgModel classes into new TxMsgTable and RxMsgTable classes.
### Toggle preventing changes from being sent until Apply button is clicked
- If "queue changes" toggle is inactive, changes will immediately apply like before.
- If toggle is active, edits to value will not be transmitted until the "Apply" button is pressed
- Turning off "queue changes" mode while changes are currently queued will apply those changes
- Column in Tx tables to show currently transmitted values
- This column is NOT editable. It could be but I think that feature isn't necessary and could be confusing.
- Values with queued changes are highlighted

### Add search feature for signals
- Search bar on top right of each tab
- Highlights rows with matching name or desc
- Search performed on string change
- "Chrome-like" behaviour
- Esc to deselect search bar
- Ctrl + f to focus search bar and select all text
- Cursor and selection position are conserved when switching between tabs
- Enter and Shift+Enter to seek next/prev result

### Time sent and received indicator
- While sending, TX tables will have timestamp of the most recently sent message.
- This time will update with periodic send.
- Rx tables will indicate the time the most recent message was received.
- Rx also indicates the gap between the two most recently received messages.

### Misc
- Tx table will convert string to hex value when string begins with "0x"
- Fixed logs not recording Tx messages.
- Columns are now resizable
- Build uses Nuitka 2.2.3 instead of latest because at some point the bundled Pyside6 libraries stopped working with my ubuntu.