### PR TITLE
Add support for SocketCAN interfaces.

### DIFF
--- a/can_testbench.py
+++ b/can_testbench.py
@@ -389,6 +389,7 @@ class MsgGraphWindow(QWidget):
 class Interface(enum.Enum):
     slcan = 0
     udp_multicast = 1
+    socketcan = 2
 
 
 SLCAN_BITRATES = (10000, 20000, 50000, 100000, 125000, 250000, 500000, 750000, 1000000, 83300)
@@ -419,6 +420,9 @@ class CanConfig():
             {'interface': Interface.udp_multicast.name,
             'channel': '239.0.0.1',
             'port': '10000',
+            'receive_own_messages': 'False'},
+            {'interface': Interface.socketcan.name,
+            'channel': 'vcan0',
             'receive_own_messages': 'False'}
         ]
         self.initConfig()


### PR DESCRIPTION
Add "socketcan" as a CanConfig option so that we can set up virtual CAN interfaces for testing and/or simulation.