### PR TITLE
Feature/fix tx logs

### DIFF
--- a/can_testbench.py
+++ b/can_testbench.py
@@ -134,8 +134,9 @@ class CanBusHandler(QtCore.QObject):
         if logFile != '':
             self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
             self.messageSent.connect(self.logger.on_message_received)
+            self.messageReceived.connect(self.logger.on_message_received)
             #self.logger = pycan.ASCWriter(logFile, channel)
-            notifyList.append(self.logger)
+            # notifyList.append(self.logger)
         self.notifier = pycan.Notifier(self.bus, notifyList)
 
     def sendCanMessage(self, msg, frequency=0):
@@ -174,6 +175,7 @@ class CanBusHandler(QtCore.QObject):
                 sendDetails['task'].start()
     
     def emitMessageSend(self, message: pycan.Message):
+        message.timestamp = time.time()
         self.messageSent.emit(message, self.listener.channel)
         
     def stop(self, msg):

--- a/can_testbench.py
+++ b/can_testbench.py
@@ -135,8 +135,6 @@ class CanBusHandler(QtCore.QObject):
             self.logger = pycan.CanutilsLogWriter(logFile, channel, True)
             self.messageSent.connect(self.logger.on_message_received)
             self.messageReceived.connect(self.logger.on_message_received)
-            #self.logger = pycan.ASCWriter(logFile, channel)
-            # notifyList.append(self.logger)
         self.notifier = pycan.Notifier(self.bus, notifyList)
 
     def sendCanMessage(self, msg, frequency=0):


### PR DESCRIPTION
I think I fixed Tx and Rx messages writing to the log file simultaneously. Went from being able to reproduce it 4/6 times to not being able to reproduce it for 5 times in a row. 

Previously, I added the logger to the notifier object’s notify list, but that only notifies on received messages so I also added a Qt signal to trigger the logger for sent messages. I switched to using Qt signals for both received and sent messages instead of the notifier, and Qt signals have built-in logic to prevent simultaneous triggers.

Also fixed timestamps not updating for periodic Tx messages.