### PR TITLE
Can send now avoids some errors even if DBC file is inaccurate.

### DIFF
--- a/can_send.py
+++ b/can_send.py
@@ -20,7 +20,7 @@ class msg_sender():
                 self.signal_db[signal.name] = {'minimum':signal.conversion.numeric_scaled_to_raw(signal.minimum),
                                                'maximum':min(int(signal.conversion.numeric_scaled_to_raw(signal.maximum)),
                                                              pow(2, signal.length - int(signal.is_signed)) - 1)}
-                self.signal_values[signal.name] = self.signal_db[signal.name]['maximum']
+                self.signal_values[signal.name] = self.signal_db[signal.name]['minimum']
             elif signal.choices is not None:
                 self.signal_db[signal.name] = list(signal.choices.keys())
                 self.signal_values[signal.name] = random.choice(self.signal_db[signal.name])
@@ -36,9 +36,9 @@ class msg_sender():
 
         for key in self.signal_values:
             if isinstance(self.signal_db[key], dict):
-                self.signal_values[key] -= 1
-                if self.signal_values[key] < self.signal_db[key]['minimum']:
-                    self.signal_values[key] = self.signal_db[key]['maximum']
+                self.signal_values[key] += 1
+                if self.signal_values[key] > self.signal_db[key]['maximum']:
+                    self.signal_values[key] = self.signal_db[key]['minimum']
             else:
                 self.signal_values[key] = random.choice(self.signal_db[key])
 

--- a/can_send.py
+++ b/can_send.py
@@ -16,9 +16,11 @@ class msg_sender():
         self.signal_values = {}
         self.signal_db = {}
         for signal in self.msg.signals:
-            if signal.minimum is not None:
-                self.signal_values[signal.name] = signal.minimum
-                self.signal_db[signal.name] = {'minimum':signal.minimum, 'maximum':signal.maximum}
+            if not signal.minimum == None and not signal.maximum == None:
+                self.signal_db[signal.name] = {'minimum':signal.conversion.numeric_scaled_to_raw(signal.minimum),
+                                               'maximum':min(int(signal.conversion.numeric_scaled_to_raw(signal.maximum)),
+                                                             pow(2, signal.length - int(signal.is_signed)) - 1)}
+                self.signal_values[signal.name] = self.signal_db[signal.name]['maximum']
             elif signal.choices is not None:
                 self.signal_db[signal.name] = list(signal.choices.keys())
                 self.signal_values[signal.name] = random.choice(self.signal_db[signal.name])
@@ -27,21 +29,22 @@ class msg_sender():
                 self.signal_db[signal.name] = {'minimum':0, 'maximum':1}
         
     def send_message(self):
-        data = self.msg.encode(self.signal_values)
+        # print(self.signal_values)
+        data = self.msg.encode(self.signal_values, scaling=False)
         message = can.Message(arbitration_id=self.msg.frame_id, data=data, is_extended_id=True)
         self.bus.send(message)
 
         for key in self.signal_values:
             if isinstance(self.signal_db[key], dict):
-                self.signal_values[key] += 1
-                if self.signal_values[key] > self.signal_db[key]['maximum']:
-                    self.signal_values[key] = self.signal_db[key]['minimum']
+                self.signal_values[key] -= 1
+                if self.signal_values[key] < self.signal_db[key]['minimum']:
+                    self.signal_values[key] = self.signal_db[key]['maximum']
             else:
                 self.signal_values[key] = random.choice(self.signal_db[key])
 
 if __name__ == '__main__':
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)
-    db = cantools.database.load_file('../envgo/dbc/testbench_motor.dbc')
+    db = cantools.database.load_file('../envgo/dbc/testbench_hydraulics.dbc')
 
     assert(isinstance(db, Database))
     

--- a/can_send.py
+++ b/can_send.py
@@ -4,6 +4,7 @@ import cantools
 import cantools.database
 from cantools.database.can.database import Database
 import random
+import argparse
 
 bus = None
 
@@ -43,8 +44,14 @@ class msg_sender():
                 self.signal_values[key] = random.choice(self.signal_db[key])
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                        prog='can_send',
+                        description='Tests sending all messages for a specified dbc file')    
+    parser.add_argument('-f', '--dbc', help="default=../envgo/dbc/testbench_motor.dbc", default="../envgo/dbc/testbench_motor.dbc")
+    args = parser.parse_args()
+    
     bus = can.Bus(interface='udp_multicast', channel='239.0.0.1', port=10000, receive_own_messages=False)
-    db = cantools.database.load_file('../envgo/dbc/testbench_hydraulics.dbc')
+    db = cantools.database.load_file(args.dbc)
 
     assert(isinstance(db, Database))
     


### PR DESCRIPTION
Previously, if the DBC file defined a maximum for a signal that doesn't fit in the signal's bit length, can_send.py would error. Now the script determines maximum based on bit length and takes the smaller of the two.